### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "0.2.1-SNAPSHOT")
 
 ```
 
-3. Create a folder called ui in the project route
+3. Create a folder called ui in the project folder
 
 4. Start sbt
 


### PR DESCRIPTION
It took me some seconds to get what was meant be "project route". A quick fix to save others' time :-)
