### PR TITLE
Start "grunt server" with --force to keep it running on coffeescript errors

### DIFF
--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -46,7 +46,7 @@ object Yeoman extends Plugin {
     playOnStarted <+= yeomanDirectory {
       base =>
         (address: InetSocketAddress) => {
-          Grunt.process = Some(Process("grunt server", base).run)
+          Grunt.process = Some(Process("grunt server --force", base).run)
         }: Unit
     },
 


### PR DESCRIPTION
Currently grunt server exists when in encounters error in the CoffeeScript code, which makes it pretty inconvenient to write/debug CS. Adding --force flag keeps server running also in case of any errors.
