### PR TITLE
Update Yeoman.scala in sbt plugin to be able to specify a gruntfile name

### DIFF
--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -24,7 +24,8 @@ import scala.Some
 
 object Yeoman extends Plugin {
   val yeomanDirectory = SettingKey[File]("yeoman-directory")
-
+  val yeomanGruntfile = SettingKey[String]("yeoman-gruntfile")
+  
   val yeomanSettings: Seq[Project.Setting[_]] = Seq(
     libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.5.2" intransitive()),
 
@@ -38,6 +39,8 @@ object Yeoman extends Plugin {
     yeomanDirectory <<= (baseDirectory in Compile) {
       _ / "ui"
     },
+    
+    yeomanGruntfile := "Gruntfile.js",
 
     // Add the views to the dist
     playAssetsDirectories <+= (yeomanDirectory in Compile)(base => base / "dist"),
@@ -47,9 +50,9 @@ object Yeoman extends Plugin {
       base =>
         (address: InetSocketAddress) => {
           if (System.getProperty("os.name").startsWith("Windows"))
-            Grunt.process = Some(Process("cmd /c grunt server --force", base).run)
+            Grunt.process = Some(Process("cmd /c grunt --gruntfile="+ yeomanGruntfile+" server --force", base).run)
           else
-            Grunt.process = Some(Process("grunt server --force", base).run)
+            Grunt.process = Some(Process("grunt --gruntfile="+ yeomanGruntfile+" server --force", base).run)
         }: Unit
     },
 


### PR DESCRIPTION
able to define which gruntfile to use (in case you have a couple).

Note: This seems to compile but is untested. I think the string concat for building the gruntfile name is wrong. I only just started messing with sbt settings so i'm not sure what's the right way to do this. I'm sure it's an easy fix for anyone with some sbt settings knowledge.
