### PR TITLE
Feature/reliable templates

### DIFF
--- a/play-yeoman/project/plugins.sbt
+++ b/play-yeoman/project/plugins.sbt
@@ -5,5 +5,5 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.2")
 

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -37,6 +37,9 @@ object Yeoman extends Plugin {
 
   private val gruntDist = TaskKey[Unit]("Task to run dist grunt")
 
+  private val gruntClean = TaskKey[Unit]("Task to run grunt clean")
+
+
   val yeomanSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.7.1-SNAPSHOT" intransitive()),
 
@@ -67,9 +70,18 @@ object Yeoman extends Plugin {
       runGrunt(base, gruntFile, List("--force")).get.exitValue()
     },
 
+    gruntClean := {
+      val base = (yeomanDirectory in Compile).value
+      val gruntFile = (yeomanGruntfile in Compile).value
+      //stringToProcess("grunt " + (Def.spaceDelimited("<arg>").parsed).mkString(" ")).!!,
+      runGrunt(base, gruntFile, List("clean")).get.exitValue()
+    },
+
     dist <<= dist dependsOn (gruntDist),
 
     stage <<= stage dependsOn (gruntDist),
+
+    clean <<= clean dependsOn (gruntClean),
 
     // Add the views to the dist
     unmanagedResourceDirectories in Assets <+= (yeomanDirectory in Compile)(base => base / "dist"),

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -67,7 +67,7 @@ object Yeoman extends Plugin {
       val base = (yeomanDirectory in Compile).value
       val gruntFile = (yeomanGruntfile in Compile).value
       //stringToProcess("grunt " + (Def.spaceDelimited("<arg>").parsed).mkString(" ")).!!,
-      runGrunt(base, gruntFile, List("--force")).get.exitValue()
+      runGrunt(base, gruntFile, List("build-dist")).get.exitValue()
     },
 
     gruntClean := {
@@ -102,7 +102,7 @@ object Yeoman extends Plugin {
 
 
   val withTemplates = Seq(
-    sourceDirectories in TwirlKeys.compileTemplates in Compile ++= Seq(Yeoman.yeomanDirectory.value / "dist"),
+    sourceDirectories in TwirlKeys.compileTemplates in Compile ++= Seq(Yeoman.yeomanDirectory.value / "twirl"),
     yeomanExcludes <<= (yeomanDirectory)(yd => Seq(
       yd + "/dist/components/",
       yd + "/dist/images/",
@@ -152,11 +152,14 @@ object Yeoman extends Plugin {
     def apply(base: File, gruntFile: String): PlayRunHook = {
 
       object GruntProcess extends PlayRunHook {
-
         var process: Option[Process] = None
 
+        override def beforeStarted(): Unit = {
+          runGrunt(base, gruntFile, "build-dev" :: Nil)
+        }
+
         override def afterStarted(addr: InetSocketAddress): Unit = {
-          process = runGrunt(base, gruntFile, "watch" :: "--force" :: Nil)
+          process = runGrunt(base, gruntFile, "watch" :: Nil)
         }
 
         override def afterStopped(): Unit = {


### PR DESCRIPTION
My "works for me" solution to issue #35.   Up for discussion.


See companion patch to Gruntfile.js in commit (or pasted right here below)

```
diff --git a/ui/Gruntfile.js b/ui/Gruntfile.js
index a5365af..225ae08 100644
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -132,6 +132,12 @@ module.exports = function (grunt) {
 
     // Empties folders to start fresh
     clean: {
+      twirl: {
+        files: [{
+          dot: true,
+          src:['twirl']
+        }]
+      },
       dist: {
         files: [{
           dot: true,
@@ -333,6 +339,24 @@ module.exports = function (grunt) {
 
     // Copies remaining files to places other tasks can use
     copy: {
+      'twirl-dev': {
+        files: [{
+           expand: true,
+           dot: true,
+           cwd: '<%= yeoman.app %>',
+           dest: 'twirl',
+           src: ['*.scala.html']
+        }]
+      },
+      'twirl-dist': {
+         files: [{
+           expand: true,
+           dot: true,
+           cwd: '<%= yeoman.dist %>',
+           dest: 'twirl',
+           src: ['*.scala.html']
+         }]
+      },
       dist: {
         files: [{
           expand: true,
@@ -400,7 +424,6 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean:server',
       'wiredep',
-      'concurrent:server',
       'autoprefixer',
       'watch'
     ]);
@@ -419,7 +442,13 @@ module.exports = function (grunt) {
     'karma'
   ]);
 
-  grunt.registerTask('build', [
+  grunt.registerTask('build-dev', [
+    'clean:twirl',
+    'copy:twirl-dev'
+  ]);
+
+  grunt.registerTask('build-dist', [
+    'clean:twirl',
     'clean:dist',
     'wiredep',
     'useminPrepare',
@@ -432,12 +461,13 @@ module.exports = function (grunt) {
     'cssmin',
     'uglify',
     'filerev',
-    'usemin'
+    'usemin',
+    'copy:twirl-dist'
   ]);
 
   grunt.registerTask('default', [
     'newer:jshint',
 //    'test',
-    'build'
+    'build-dev'
   ]);
 };
```