### PR TITLE
0.8.0-SNAPSHOT: preparing for play-2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ module.exports = function (grunt) {
     // To fully minify generated html, use https://github.com/mohiva/play-html-compressor
     replace: {
       htmlmin: {
-	src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
-	overwrite: true,
-	replacements: [
-	  {from: /^\s+/mg, to: ''},
-	  {from: /\s\s+/mg, to: ' '}
-	]
+        src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
+        overwrite: true,
+        replacements: [
+          {from: /^\s+/mg, to: ''},
+          {from: /\s\s+/mg, to: ' '}
+        ]
       }
     },
 
@@ -285,12 +285,12 @@ module.exports = function (grunt) {
     // To fully minify generated html, use https://github.com/mohiva/play-html-compressor
     replace: {
       htmlmin: {
-	src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
-	overwrite: true,
-	replacements: [
-	  {from: /^\s+/mg, to: ''},
-	  {from: /\s\s+/mg, to: ' '}
-	]
+        src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
+        overwrite: true,
+        replacements: [
+          {from: /^\s+/mg, to: ''},
+          {from: /\s\s+/mg, to: ' '}
+        ]
       }
     },
 
@@ -300,50 +300,50 @@ module.exports = function (grunt) {
     // Copies remaining files to places other tasks can use
     copy: {
       'twirl-dev': {
-	files: [{
-	  expand: true,
-	  dot: true,
-	  cwd: '<%= yeoman.app %>',
-	  dest: '<%= yeoman.dist %>',
-	  src: ['**/*.scala.html']
-	}]
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '<%= yeoman.dist %>',
+          src: ['**/*.scala.html']
+        }]
       },
       'twirl-dist': {
-	files: [{
-	  expand: true,
-	  dot: true,
-	  cwd: '<%= yeoman.dist %>',
-	  dest: 'twirl',
-	  src: ['**/*.scala.html']
-	}]
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.dist %>',
+          dest: 'twirl',
+          src: ['**/*.scala.html']
+        }]
       },
       dist: {
-	files: [{
-	  expand: true,
-	  dot: true,
-	  cwd: '<%= yeoman.app %>',
-	  dest: '<%= yeoman.dist %>',
-	  src: [
-	    '*.{ico,png,txt}',
-	    '.htaccess',
-	    '*.html',
-	    'views/**/*.html',
-	    'views/**/*.txt',
-	    'images/**/*.{webp}',
-	    'fonts/**/*.*'
-	  ]
-	}, {
-	  expand: true,
-	  cwd: '.tmp/images',
-	  dest: '<%= yeoman.dist %>/images',
-	  src: ['generated/*']
-	}]
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '<%= yeoman.dist %>',
+          src: [
+            '*.{ico,png,txt}',
+            '.htaccess',
+            '*.html',
+            'views/**/*.html',
+            'views/**/*.txt',
+            'images/**/*.{webp}',
+            'fonts/**/*.*'
+          ]
+        }, {
+          expand: true,
+          cwd: '.tmp/images',
+          dest: '<%= yeoman.dist %>/images',
+          src: ['generated/*']
+        }]
       },
       styles: {
-	expand: true,
-	cwd: '<%= yeoman.app %>/styles',
-	dest: '.tmp/styles/',
-	src: '{,*/}*.css'
+        expand: true,
+        cwd: '<%= yeoman.app %>/styles',
+        dest: '.tmp/styles/',
+        src: '{,*/}*.css'
       },
       ...
     }, // end 'copy'

--- a/README.md
+++ b/README.md
@@ -174,13 +174,17 @@ Note: If you are using Scala Templates support in play-yeoman 0.7.1, ensure that
         'usemin'/*,
         'htmlmin' */
     ]);
+```
 
 For scala templates early minification you can use `grunt-text-replace` task.
 In file `app/package.json` in section `devDependencies` add
+
 ```
   "grunt-text-replace": "^0.4.0"
 ```
+
 Do not forget to call `npm install` in sbt console and edit your `app/Gruntfile.js` in following way:
+
 ```
 ...
 module.exports = function (grunt) {

--- a/README.md
+++ b/README.md
@@ -174,7 +174,37 @@ Note: If you are using Scala Templates support in play-yeoman 0.7.1, ensure that
         'usemin'/*,
         'htmlmin' */
     ]);
+
+For scala templates early minification you can use `grunt-text-replace` task.
+In file `app/package.json` in section `devDependencies` add
 ```
+  "grunt-text-replace": "^0.4.0"
+```
+Do not forget to call `npm install` in sbt console and edit your `app/Gruntfile.js` in following way:
+```
+...
+module.exports = function (grunt) {
+  
+  ...
+  grunt.initConfig({
+    ...
+    // Add replace:htmlmin task.
+    // Using simple regex replace to minify html templates instead of htmlmin, because htmlmin will not/never work stable on scala templates.
+    // To fully minify generated html, use https://github.com/mohiva/play-html-compressor
+    replace: {
+      htmlmin: {
+	src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
+	overwrite: true,
+	replacements: [
+	  {from: /^\s+/mg, to: ''},
+	  {from: /\s\s+/mg, to: ' '}
+	]
+      }
+    },
+
+    ...
+```
+For taking support of scala templates recompilation on reload, read next section carefully before `run`.
 
 10) Run your play application,
 
@@ -224,6 +254,128 @@ Using 0.7.1
 
 ```
 
+Using 0.8.4+ (play 2.4+)
+Edit your `app/Gruntfile.js` in following way:
+```
+...
+module.exports = function (grunt) {
+  
+  ...
+  grunt.initConfig({
+    ...
+
+    // Add watch:scalaTpl task.
+    // During sbt run, will copy any modified scala templates into dist directory.
+    // PlayReloader will see changes in dist in every reload and recompile changed scala templates.
+    watch: {
+      ...
+      scalaTpl: {
+        files: ['<%= yeoman.app %>/views/**/*.scala.*'],                                                                                                               
+        tasks: ['newer:copy:twirl-dev']
+      }
+    },
+
+    ...
+    // Add replace:htmlmin task.
+    // Using simple regex replace to minify html templates instead of htmlmin, because htmlmin will not/never work stable on scala templates.
+    // To fully minify generated html, use https://github.com/mohiva/play-html-compressor
+    replace: {
+      htmlmin: {
+	src: ['<%= yeoman.dist %>/**/*.html'],  // source files array (supports minimatch)
+	overwrite: true,
+	replacements: [
+	  {from: /^\s+/mg, to: ''},
+	  {from: /\s\s+/mg, to: ' '}
+	]
+      }
+    },
+
+    ...
+
+    // Add copy tasks for twirl templates.
+    // Copies remaining files to places other tasks can use
+    copy: {
+      'twirl-dev': {
+	files: [{
+	  expand: true,
+	  dot: true,
+	  cwd: '<%= yeoman.app %>',
+	  dest: '<%= yeoman.dist %>',
+	  src: ['**/*.scala.html']
+	}]
+      },
+      'twirl-dist': {
+	files: [{
+	  expand: true,
+	  dot: true,
+	  cwd: '<%= yeoman.dist %>',
+	  dest: 'twirl',
+	  src: ['**/*.scala.html']
+	}]
+      },
+      dist: {
+	files: [{
+	  expand: true,
+	  dot: true,
+	  cwd: '<%= yeoman.app %>',
+	  dest: '<%= yeoman.dist %>',
+	  src: [
+	    '*.{ico,png,txt}',
+	    '.htaccess',
+	    '*.html',
+	    'views/**/*.html',
+	    'views/**/*.txt',
+	    'images/**/*.{webp}',
+	    'fonts/**/*.*'
+	  ]
+	}, {
+	  expand: true,
+	  cwd: '.tmp/images',
+	  dest: '<%= yeoman.dist %>/images',
+	  src: ['generated/*']
+	}]
+      },
+      styles: {
+	expand: true,
+	cwd: '<%= yeoman.app %>/styles',
+	dest: '.tmp/styles/',
+	src: '{,*/}*.css'
+      },
+      ...
+    }, // end 'copy'
+
+    ...
+  }
+
+  // 'build' task not used, you can remove it. Add build-dev and build-dist tasks in such way:
+  grunt.registerTask('build-dev', [
+    'copy:twirl-dev',
+  ]);
+
+  grunt.registerTask('build-dist', [
+    'clean:dist',
+    'wiredep',
+    'useminPrepare',
+    'concurrent:dist',
+    'autoprefixer',
+    'concat',
+    'ngAnnotate',
+    'copy:dist',
+    'cdnify',
+    'cssmin',
+    'uglify',
+    'filerev',
+    'usemin',
+    'replace:htmlmin',
+    'copy:twirl-dist'
+  ]);
+  
+  ...
+```
+As you can see, Gruntfile described does not use `htmlmin` postprocessor.
+If you are alse not use it, feel free to remove it from `package.json` dependencies.
+
+
 * Once that is done play will compile the templates from yeoman directory too, and you can use them in your controllers. This helps you keep all your UI files together under the yeoman directory ('ui' by default)
 
 * Look at the yo-demo project for details!
@@ -231,6 +383,9 @@ Using 0.7.1
 Note: In 0.7.1, play-yeoman supports compilation of views from the yeoman directory but cannot recompile them when they are modified with the server running. You will need to stop the server and start it again.
 
 * If you use scala template support, you need to run grunt prior to compile else the template code will not be generated. This is not required if you execute run or stage directly since they have a dependency on grunt.  
+
+* You can fix this problems via `Gruntfile.js` (see 0.8.4+ section above).
+
 
 ### Taking it to production
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ How to use it?
 addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "play-compatible-version")
 
 ```
-play-compatible-version = 0.7.1 for Play 2.3.0 and 0.6.4 for Play 2.2.x
+play-compatible-version = 0.8.0-SNAPSHOT for Play 2.4.0-M2+, 0.7.1 for Play 2.3.0 and 0.6.4 for Play 2.2.x
 
 Note: support for Scala 2.11 is available from version 0.7.1 
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ module.exports = function (grunt) {
   ...
 ```
 As you can see, Gruntfile described does not use `htmlmin` postprocessor.
-If you are alse not use it, feel free to remove it from `package.json` dependencies.
+If you are also have no plans to use it, feel free to remove it from `package.json` dependencies.
 
 
 * Once that is done play will compile the templates from yeoman directory too, and you can use them in your controllers. This helps you keep all your UI files together under the yeoman directory ('ui' by default)

--- a/README.md
+++ b/README.md
@@ -38,25 +38,9 @@ How to use it?
 addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "play-compatible-version")
 
 ```
-play-compatible-version = 0.7.0 for Play 2.3.0 and 0.6.4 for Play 2.2.x
+play-compatible-version = 0.7.1 for Play 2.3.0 and 0.6.4 for Play 2.2.x
 
-If you are really impatient or are using Scala 2.11, you can use the 0.7.1-SNAPSHOT using the following code.
-
-```
-
-resolvers += Resolver.sonatypeRepo("snapshots")
-
-addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "0.7.1-SNAPSHOT")
-
-```
-
-You will also have to add the snapshot resolver to build (project/Build.scala orr build.sbt) file too,
-
-```
-
-resolvers += Resolver.sonatypeRepo("snapshots")
-
-```
+Note: support for Scala 2.11 is available from version 0.7.1 
 
 
 3) Import Yeoman classes in the project build adding the following import to `project/Build.scala`,
@@ -80,7 +64,7 @@ Using 0.6.4
 ```
 
 
-Using 0.7.0
+Using 0.7.1
 
 ```scala
   val appSettings = Seq(version := appVersion, libraryDependencies ++= appDependencies) ++
@@ -171,7 +155,7 @@ user yo-demo> sbt
 
 ```
 
-Note: If you are using Scala Templates support in play-yeoman 0.7.0, ensure that "htmlmin" task is not called during the "build" since it does not understand Scala templates. This can be done by updating the build task in Gruntfile.js,
+Note: If you are using Scala Templates support in play-yeoman 0.7.1, ensure that "htmlmin" task is not called during the "build" since it does not understand Scala templates. This can be done by updating the build task in Gruntfile.js,
 
 ```
     grunt.registerTask('build', [
@@ -226,7 +210,7 @@ Using 0.6.4
 
 ```
 
-Using 0.7.0
+Using 0.7.1
 
 ```
    val appSettings = Seq(version := appVersion, libraryDependencies ++= appDependencies) ++
@@ -244,7 +228,7 @@ Using 0.7.0
 
 * Look at the yo-demo project for details!
 
-Note: In 0.7.0, play-yeoman supports compilation of views from the yeoman directory but cannot recompile them when they are modified with the server running. You will need to stop the server and start it again.
+Note: In 0.7.1, play-yeoman supports compilation of views from the yeoman directory but cannot recompile them when they are modified with the server running. You will need to stop the server and start it again.
 
 * If you use scala template support, you need to run grunt prior to compile else the template code will not be generated. This is not required if you execute run or stage directly since they have a dependency on grunt.  
 
@@ -264,6 +248,11 @@ For this purpose play-yeoman provides 2 settings that you can use in you play pr
 2) yeoman.devDirs - This is a List of String that takes a list of locations where play-yeoman should look for files in development mode i.e. when run using sbt run.
 
 
+Note: Starting from 0.7.1, it is possible to disable force option on execution of grunt tasks. This can be done by adding the following to the application build settings,
+
+```
+Yeoman.forceGrunt := false
+```
 
 Licence
 =======

--- a/notes/0.7.1.markdown
+++ b/notes/0.7.1.markdown
@@ -1,0 +1,5 @@
+New in this release -
+
++ Support for Scala 2.11
++ fixes #50
++ a setting to disable --force option on grunt tasks (fixes #40)

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.8.4-SNAPSHOT"
+  val appVersion = "0.8.5-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.7.1-SNAPSHOT"
+  val appVersion = "0.7.1"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.7.1"
+  val appVersion = "0.8.0-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,
@@ -18,8 +18,8 @@ object ApplicationBuild extends Build {
     version := appVersion,
     libraryDependencies ++= appDependencies,
     // Add your own project settings here
-    scalaVersion in Global := "2.10.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.1"),
+    scalaVersion in Global := "2.11.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     homepage := Some(url("https://github.com/tuplejump/play-yeoman")),
     organization := "com.tuplejump",
     organizationName := "Tuplejump Software PVt. Ltd.",

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.8.0-SNAPSHOT"
+  val appVersion = "0.8.1-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.8.5-SNAPSHOT"
+  val appVersion = "0.8.7-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/play-yeoman/project/Build.scala
+++ b/play-yeoman/project/Build.scala
@@ -6,7 +6,7 @@ import PlayKeys._
 object ApplicationBuild extends Build {
 
   val appName = "play-yeoman"
-  val appVersion = "0.8.1-SNAPSHOT"
+  val appVersion = "0.8.4-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/play-yeoman/project/build.properties
+++ b/play-yeoman/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/play-yeoman/project/plugins.sbt
+++ b/play-yeoman/project/plugins.sbt
@@ -5,5 +5,5 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M2")
 

--- a/play-yeoman/project/plugins.sbt
+++ b/play-yeoman/project/plugins.sbt
@@ -5,5 +5,5 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M3")
 

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -43,7 +43,7 @@ object Yeoman extends Plugin {
 
 
   val yeomanSettings: Seq[Def.Setting[_]] = Seq(
-    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.4-SNAPSHOT" intransitive()),
+    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.5-SNAPSHOT" intransitive()),
 
     // Where does the UI live?
     yeomanDirectory <<= (baseDirectory in Compile) {

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -42,7 +42,7 @@ object Yeoman extends Plugin {
 
 
   val yeomanSettings: Seq[Def.Setting[_]] = Seq(
-    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.0-SNAPSHOT" intransitive()),
+    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.1-SNAPSHOT" intransitive()),
 
     // Where does the UI live?
     yeomanDirectory <<= (baseDirectory in Compile) {

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -39,13 +39,7 @@ object Yeoman extends Plugin {
   private val gruntDist = TaskKey[Unit]("Task to run dist grunt")
 
   val yeomanSettings: Seq[Def.Setting[_]] = Seq(
-    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.7.1" intransitive()),
-
-    // Turn off play's internal less compiler
-    lessEntryPoints := Nil,
-
-    // Turn off play's internal javascript compiler
-    javascriptEntryPoints := Nil,
+    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.0-SNAPSHOT" intransitive()),
 
     // Where does the UI live?
     yeomanDirectory <<= (baseDirectory in Compile) {

--- a/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
+++ b/sbt-yeoman/app/com/tuplejump/sbt/yeoman/Yeoman.scala
@@ -23,7 +23,7 @@ import play.Play.autoImport._
 import PlayKeys._
 import com.typesafe.sbt.web.Import._
 
-import com.typesafe.sbt.packager.universal.Keys._
+import com.typesafe.sbt.packager.Keys._
 import play.PlayRunHook
 import play.twirl.sbt.Import._
 
@@ -43,7 +43,7 @@ object Yeoman extends Plugin {
 
 
   val yeomanSettings: Seq[Def.Setting[_]] = Seq(
-    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.5-SNAPSHOT" intransitive()),
+    libraryDependencies ++= Seq("com.tuplejump" %% "play-yeoman" % "0.8.7-SNAPSHOT" intransitive()),
 
     // Where does the UI live?
     yeomanDirectory <<= (baseDirectory in Compile) {

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,7 +4,7 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.8.0-SNAPSHOT"
+version := "0.8.1-SNAPSHOT"
 
 sbtVersion in Global := "0.13.5"
 
@@ -39,6 +39,7 @@ Seq(
 
 publishMavenStyle := true
 
+/*
 publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"
   if (v.trim.endsWith("SNAPSHOT"))
@@ -48,7 +49,7 @@ publishTo <<= version { (v: String) =>
 }
 
 publishArtifact in Test := false
-
+*/
 pomIncludeRepository := { _ => false }
 
 pomExtra := (

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,19 +4,19 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.7.1"
+version := "0.8.0-SNAPSHOT"
 
 sbtVersion in Global := "0.13.5"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test"
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.2")
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,7 +4,7 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.8.1-SNAPSHOT"
+version := "0.8.4-SNAPSHOT"
 
 sbtVersion in Global := "0.13.5"
 

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,7 +4,7 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.7.1-SNAPSHOT"
+version := "0.7.1"
 
 sbtVersion in Global := "0.13.5"
 

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,7 +4,7 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.8.5-SNAPSHOT"
+version := "0.8.7-SNAPSHOT"
 
 sbtVersion in Global := "0.13.5"
 
@@ -14,7 +14,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test"
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.2")
 

--- a/sbt-yeoman/build.sbt
+++ b/sbt-yeoman/build.sbt
@@ -4,7 +4,7 @@ organization := "com.tuplejump"
 
 sbtPlugin := true
 
-version := "0.8.4-SNAPSHOT"
+version := "0.8.5-SNAPSHOT"
 
 sbtVersion in Global := "0.13.5"
 

--- a/sbt-yeoman/project/build.properties
+++ b/sbt-yeoman/project/build.properties
@@ -1,5 +1,5 @@
 #
 #Fri May 10 17:37:41 IST 2013
 template.uuid=a5227c77d39109b6550a47758c2f9a1341e06524
-sbt.version=0.13.5
+sbt.version=0.13.7
 activator.abi.version=0.1.1

--- a/yo-demo/project/plugins.sbt
+++ b/yo-demo/project/plugins.sbt
@@ -1,11 +1,11 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
 
-addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "0.7.1-SNAPSHOT")
+addSbtPlugin("com.tuplejump" % "sbt-yeoman" % "0.7.1")
 


### PR DESCRIPTION
$SUBJ

Unsure about removing lines for zeroing `lessEntryPoints` and `javascriptEntryPoints`. Cannot find any alternatives. Disabling only by removing `sbt-less` and other `sbt-web` plugins from `myproj1/project/plugins.sbt`.